### PR TITLE
Modify Color 

### DIFF
--- a/Onbom/Onbom.xcodeproj/project.pbxproj
+++ b/Onbom/Onbom.xcodeproj/project.pbxproj
@@ -7,13 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		03D759362ACDA17400495D7F /* PostCodeInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D759352ACDA17400495D7F /* PostCodeInputView.swift */; };
+		03FFF2A92ACDAE7A00B81D65 /* PostCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FFF2A82ACDAE7A00B81D65 /* PostCodeView.swift */; };
 		70D2994A2AC573B3009F536A /* CameraViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D299492AC573B3009F536A /* CameraViewer.swift */; };
 		70D2994C2AC573BC009F536A /* CameraManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D2994B2AC573BC009F536A /* CameraManager.swift */; };
 		70D299512AC9617D009F536A /* PrepareIDCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D299502AC9617D009F536A /* PrepareIDCardView.swift */; };
 		70D299532AC961AB009F536A /* TakeIDCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D299522AC961AB009F536A /* TakeIDCardView.swift */; };
 		70D299552AC961BB009F536A /* ConfirmIDCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D299542AC961BB009F536A /* ConfirmIDCardView.swift */; };
-		03D759362ACDA17400495D7F /* PostCodeInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D759352ACDA17400495D7F /* PostCodeInputView.swift */; };
-		03FFF2A92ACDAE7A00B81D65 /* PostCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FFF2A82ACDAE7A00B81D65 /* PostCodeView.swift */; };
+		7337E1E82AD04B1700D91E6F /* TextStyle+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7337E1E72AD04B1700D91E6F /* TextStyle+Extension.swift */; };
 		737EE3542ABD646100D224FC /* OnbomApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 737EE3532ABD646100D224FC /* OnbomApp.swift */; };
 		737EE3562ABD646100D224FC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 737EE3552ABD646100D224FC /* ContentView.swift */; };
 		737EE3582ABD646200D224FC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 737EE3572ABD646200D224FC /* Assets.xcassets */; };
@@ -26,13 +27,14 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		03D759352ACDA17400495D7F /* PostCodeInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCodeInputView.swift; sourceTree = "<group>"; };
+		03FFF2A82ACDAE7A00B81D65 /* PostCodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCodeView.swift; sourceTree = "<group>"; };
 		70D299492AC573B3009F536A /* CameraViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraViewer.swift; sourceTree = "<group>"; };
 		70D2994B2AC573BC009F536A /* CameraManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraManager.swift; sourceTree = "<group>"; };
 		70D299502AC9617D009F536A /* PrepareIDCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepareIDCardView.swift; sourceTree = "<group>"; };
 		70D299522AC961AB009F536A /* TakeIDCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TakeIDCardView.swift; sourceTree = "<group>"; };
 		70D299542AC961BB009F536A /* ConfirmIDCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmIDCardView.swift; sourceTree = "<group>"; };
-		03D759352ACDA17400495D7F /* PostCodeInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCodeInputView.swift; sourceTree = "<group>"; };
-		03FFF2A82ACDAE7A00B81D65 /* PostCodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCodeView.swift; sourceTree = "<group>"; };
+		7337E1E72AD04B1700D91E6F /* TextStyle+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TextStyle+Extension.swift"; sourceTree = "<group>"; };
 		737EE3502ABD646100D224FC /* Onbom.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Onbom.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		737EE3532ABD646100D224FC /* OnbomApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnbomApp.swift; sourceTree = "<group>"; };
 		737EE3552ABD646100D224FC /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -139,6 +141,7 @@
 			isa = PBXGroup;
 			children = (
 				AEB33E9A2AC406600082A3E7 /* Color+Palette.swift */,
+				7337E1E72AD04B1700D91E6F /* TextStyle+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -242,6 +245,7 @@
 			files = (
 				737EE3562ABD646100D224FC /* ContentView.swift in Sources */,
 				70D299532AC961AB009F536A /* TakeIDCardView.swift in Sources */,
+				7337E1E82AD04B1700D91E6F /* TextStyle+Extension.swift in Sources */,
 				70D299552AC961BB009F536A /* ConfirmIDCardView.swift in Sources */,
 				AEB33E762AC2B0ED0082A3E7 /* PDFManager.swift in Sources */,
 				70D299512AC9617D009F536A /* PrepareIDCardView.swift in Sources */,

--- a/Onbom/Onbom/Extensions/Color+Palette.swift
+++ b/Onbom/Onbom/Extensions/Color+Palette.swift
@@ -121,10 +121,6 @@ struct Color_Previews: PreviewProvider {
                 Color.PB5
             }
             VStack {
-                Color.white
-                Color.white
-                Color.white
-                Color.white
                 Color.TG1
                 Color.TG2
                 Color.TPB

--- a/Onbom/Onbom/Extensions/Color+Palette.swift
+++ b/Onbom/Onbom/Extensions/Color+Palette.swift
@@ -65,18 +65,22 @@ extension Color {
     }
     
     static var PB1: Self {
-        .init(hex: "#EDEEFF")
+        .init(hex: "#EFF0FF")
     }
     
     static var PB2: Self {
-        .init(hex: "#C3C6FF")
+        .init(hex: "#E4E6FF")
     }
     
     static var PB3: Self {
-        .init(hex: "#575DE1")
+        .init(hex: "#C3C6FF")
     }
     
     static var PB4: Self {
+        .init(hex: "#575DE1")
+    }
+    
+    static var PB5: Self {
         .init(hex: "#343E9A")
     }
     
@@ -114,6 +118,13 @@ struct Color_Previews: PreviewProvider {
                 Color.PB2
                 Color.PB3
                 Color.PB4
+                Color.PB5
+            }
+            VStack {
+                Color.white
+                Color.white
+                Color.white
+                Color.white
                 Color.TG1
                 Color.TG2
                 Color.TPB

--- a/Onbom/Onbom/Extensions/TextStyle+Extension.swift
+++ b/Onbom/Onbom/Extensions/TextStyle+Extension.swift
@@ -1,0 +1,63 @@
+//
+//  TextStyle+Extension.swift
+//  Onbom
+//
+//  Created by moon on 10/6/23.
+//
+
+import SwiftUI
+
+extension Text {
+    func H1() -> some View {
+        self.font(.system(size:22, weight: .bold))
+    }
+    func H2() -> some View {
+        self.font(.system(size:18, weight: .heavy))
+    }
+    
+    func T1() -> some View {
+        self.font(.system(size:19, weight: .bold))
+    }
+    func T2() -> some View {
+        self.font(.system(size:18, weight: .bold))
+    }
+    func T3() -> some View {
+        self.font(.system(size:17, weight: .bold))
+    }
+    func T4() -> some View {
+        self.font(.system(size:14, weight: .bold))
+    }
+    func T5() -> some View {
+        self.font(.system(size:14, weight: .semibold))
+    }
+    
+    func B1() -> some View {
+        self.font(.system(size:16, weight: .bold))
+    }
+    func B2() -> some View {
+        self.font(.system(size:16, weight: .bold))
+    }
+    func B3() -> some View {
+        self.font(.system(size:13, weight: .medium))
+    }
+    
+    func Label() -> some View {
+        self.font(.system(size:14, weight: .semibold))
+    }
+    
+    func Cap1() -> some View {
+        self.font(.system(size:16, weight: .medium))
+    }
+    func Cap2() -> some View {
+        self.font(.system(size:15, weight: .medium))
+    }
+    func Cap3() -> some View {
+        self.font(.system(size:14, weight: .medium))
+    }
+    func Cap4() -> some View {
+        self.font(.system(size:13, weight: .medium))
+    }
+    func Cap5() -> some View {
+        self.font(.system(size:11, weight: .regular))
+    }
+}


### PR DESCRIPTION
10월 6일 회의록, 디자인시스템이 수정되어 코드에 반영함

<img width="695" alt="스크린샷 2023-10-06 오후 11 00 42" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team2-Nutty/assets/59304977/20667e65-a79b-427a-b4f4-2c79827f0a42">

## 참고
https://www.notion.so/10-6-648f5ddc2ff141b4b8b89376275116f9


## 추가
피그마 디자인시스템에 있는 Text도 익스텐션으로 추가했어요
그런데 피그마에선 자간 행간을 비율로 알려줬는데 
swiftui에선 자간 행간을 상수값으로 조절할 수 있어서 
폰트사이즈랑 굵기만 적용해줬어요