### PR TITLE
Delete firebase-initialization-code

### DIFF
--- a/Onbom/Onbom/OnbomApp.swift
+++ b/Onbom/Onbom/OnbomApp.swift
@@ -13,12 +13,6 @@ import KakaoSDKAuth
 @main
 struct OnbomApp: App {
     
-    init() {
-        FirebaseApp.configure()
-        
-        let kakaoAppKey = Bundle.main.infoDictionary?["KAKAO_NATIVE_APP_KEY"]!
-        KakaoSDK.initSDK(appKey: kakaoAppKey as! String)
-    }
     
     var body: some Scene {
         WindowGroup {


### PR DESCRIPTION
파이어베이스 초기설정이 빌드시간을 많이 잡아먹기 때문에 초기설정을 삭제한다
