### PR TITLE
49 create addidcardtopdf function and agentinfodetailview

### DIFF
--- a/Onbom/Onbom.xcodeproj/project.pbxproj
+++ b/Onbom/Onbom.xcodeproj/project.pbxproj
@@ -114,7 +114,6 @@
 		7372274E2AD476AD0021EFC6 /* FormTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormTextField.swift; sourceTree = "<group>"; };
 		737B62162AD6EAB30010444E /* PatientInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatientInfoViewModel.swift; sourceTree = "<group>"; };
 		737D49022ACB3F4F008AC5EC /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
-		737EE3502ABD646100D224FC /* Onbom.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = Onbom.app; path = "/Users/sebinkwon/Desktop/MacC-Team2-Nutty/Onbom/build/Debug-iphoneos/Onbom.app"; sourceTree = "<absolute>"; };
 		737EE3532ABD646100D224FC /* OnbomApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnbomApp.swift; sourceTree = "<group>"; };
 		737EE3552ABD646100D224FC /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		737EE3572ABD646200D224FC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -125,6 +124,7 @@
 		AE10D38F2AD4D33C00D9ED3C /* SignatureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignatureView.swift; sourceTree = "<group>"; };
 		AE10D3912AD4E1C900D9ED3C /* PrivacyPolicyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPolicyView.swift; sourceTree = "<group>"; };
 		AE57BA122ABD695800F71B34 /* File.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = File.swift; sourceTree = "<group>"; };
+		AE70A4282ADAE7500006125E /* Onbom.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Onbom.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE933EDB2AD42E36003D87E6 /* AgentInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentInfoView.swift; sourceTree = "<group>"; };
 		AE933EDD2AD42E60003D87E6 /* AgentInfoDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentInfoDetailView.swift; sourceTree = "<group>"; };
 		AEB33E752AC2B0ED0082A3E7 /* PDFManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFManager.swift; sourceTree = "<group>"; };
@@ -209,6 +209,7 @@
 			isa = PBXGroup;
 			children = (
 				737EE3522ABD646100D224FC /* Onbom */,
+				AE70A4282ADAE7500006125E /* Onbom.app */,
 			);
 			sourceTree = "<group>";
 		};
@@ -389,7 +390,7 @@
 				739F9FAB2AC1DF2300523110 /* KakaoSDKUser */,
 			);
 			productName = Onbom;
-			productReference = 737EE3502ABD646100D224FC /* Onbom.app */;
+			productReference = AE70A4282ADAE7500006125E /* Onbom.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */

--- a/Onbom/Onbom.xcodeproj/project.pbxproj
+++ b/Onbom/Onbom.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		70B136CF2AD62EF5001208E3 /* ApplicationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B136CE2AD62EF5001208E3 /* ApplicationViewModel.swift */; };
 		70D2994A2AC573B3009F536A /* CameraViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D299492AC573B3009F536A /* CameraViewer.swift */; };
 		70D2994C2AC573BC009F536A /* CameraManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D2994B2AC573BC009F536A /* CameraManager.swift */; };
+		70D299512AC9617D009F536A /* IDCardDescriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D299502AC9617D009F536A /* IDCardDescriptionView.swift */; };
 		70D299532AC961AB009F536A /* IDCardOCRView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D299522AC961AB009F536A /* IDCardOCRView.swift */; };
 		70D299552AC961BB009F536A /* ConfirmIDCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D299542AC961BB009F536A /* ConfirmIDCardView.swift */; };
 		70E047052AD5023000FC73A5 /* NavigationBarBackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70E047042AD5023000FC73A5 /* NavigationBarBackButton.swift */; };
@@ -52,13 +53,13 @@
 		737EE3582ABD646200D224FC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 737EE3572ABD646200D224FC /* Assets.xcassets */; };
 		737EE35B2ABD646200D224FC /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 737EE35A2ABD646200D224FC /* Preview Assets.xcassets */; };
 		7389872F2AD5E95A00688634 /* MediConditionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7389872E2AD5E95A00688634 /* MediConditionViewModel.swift */; };
+		739F9FA12AC1DA0D00523110 /* KakaoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 739F9FA02AC1DA0D00523110 /* KakaoSDK */; };
+		739F9FAC2AC1DF2300523110 /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = 739F9FAB2AC1DF2300523110 /* KakaoSDKUser */; };
+		73A708892ACEC605004B462B /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 73A708882ACEC605004B462B /* GoogleService-Info.plist */; };
 		AE10D3902AD4D33C00D9ED3C /* SignatureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE10D38F2AD4D33C00D9ED3C /* SignatureView.swift */; };
 		AE10D3922AD4E1C900D9ED3C /* PrivacyPolicyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE10D3912AD4E1C900D9ED3C /* PrivacyPolicyView.swift */; };
 		AE933EDC2AD42E36003D87E6 /* AgentInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE933EDB2AD42E36003D87E6 /* AgentInfoView.swift */; };
 		AE933EDE2AD42E60003D87E6 /* AgentInfoDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE933EDD2AD42E60003D87E6 /* AgentInfoDetailView.swift */; };
-		739F9FA12AC1DA0D00523110 /* KakaoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 739F9FA02AC1DA0D00523110 /* KakaoSDK */; };
-		739F9FAC2AC1DF2300523110 /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = 739F9FAB2AC1DF2300523110 /* KakaoSDKUser */; };
-		73A708892ACEC605004B462B /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 73A708882ACEC605004B462B /* GoogleService-Info.plist */; };
 		AEB33E762AC2B0ED0082A3E7 /* PDFManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB33E752AC2B0ED0082A3E7 /* PDFManager.swift */; };
 		AEB33E792AC2BDAC0082A3E7 /* PDFViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB33E782AC2BDAC0082A3E7 /* PDFViewer.swift */; };
 		AEB33E992AC3F7CE0082A3E7 /* LTCIForm.pdf in Resources */ = {isa = PBXBuildFile; fileRef = AEB33E982AC3F7CE0082A3E7 /* LTCIForm.pdf */; };
@@ -69,7 +70,6 @@
 		AEB33EA92ACAADE00082A3E7 /* PDFFormLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB33EA82ACAADE00082A3E7 /* PDFFormLocation.swift */; };
 		AEB33EAC2ACD3D010082A3E7 /* DigitalSignatureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB33EAB2ACD3D010082A3E7 /* DigitalSignatureManager.swift */; };
 		AEB33EAE2ACD3D680082A3E7 /* TempWriteSignatureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB33EAD2ACD3D680082A3E7 /* TempWriteSignatureView.swift */; };
-		70D299512AC9617D009F536A /* IDCardDescriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D299502AC9617D009F536A /* IDCardDescriptionView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -114,17 +114,16 @@
 		7372274E2AD476AD0021EFC6 /* FormTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormTextField.swift; sourceTree = "<group>"; };
 		737B62162AD6EAB30010444E /* PatientInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatientInfoViewModel.swift; sourceTree = "<group>"; };
 		737D49022ACB3F4F008AC5EC /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
-		737EE3502ABD646100D224FC /* Onbom.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Onbom.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		737EE3502ABD646100D224FC /* Onbom.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = Onbom.app; path = "/Users/sebinkwon/Desktop/MacC-Team2-Nutty/Onbom/build/Debug-iphoneos/Onbom.app"; sourceTree = "<absolute>"; };
 		737EE3532ABD646100D224FC /* OnbomApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnbomApp.swift; sourceTree = "<group>"; };
 		737EE3552ABD646100D224FC /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		737EE3572ABD646200D224FC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		737EE35A2ABD646200D224FC /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		7389872E2AD5E95A00688634 /* MediConditionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediConditionViewModel.swift; sourceTree = "<group>"; };
-		AE57BA122ABD695800F71B34 /* File.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = File.swift; sourceTree = "<group>"; };
-		AE10D38F2AD4D33C00D9ED3C /* SignatureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignatureView.swift; sourceTree = "<group>"; };
-		AE10D3912AD4E1C900D9ED3C /* PrivacyPolicyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPolicyView.swift; sourceTree = "<group>"; };
 		739F9FAA2AC1DB4300523110 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		73A708882ACEC605004B462B /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		AE10D38F2AD4D33C00D9ED3C /* SignatureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignatureView.swift; sourceTree = "<group>"; };
+		AE10D3912AD4E1C900D9ED3C /* PrivacyPolicyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPolicyView.swift; sourceTree = "<group>"; };
 		AE57BA122ABD695800F71B34 /* File.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = File.swift; sourceTree = "<group>"; };
 		AE933EDB2AD42E36003D87E6 /* AgentInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentInfoView.swift; sourceTree = "<group>"; };
 		AE933EDD2AD42E60003D87E6 /* AgentInfoDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentInfoDetailView.swift; sourceTree = "<group>"; };
@@ -157,7 +156,6 @@
 		708891E92AD5515B005B67AB /* Address */ = {
 			isa = PBXGroup;
 			children = (
-				03FFF2A82ACDAE7A00B81D65 /* PostCodeView.swift */,
 				03D759352ACDA17400495D7F /* PostCodeInputView.swift */,
 				708891EA2AD55191005B67AB /* AddressFormView.swift */,
 			);
@@ -199,13 +197,6 @@
 			path = IDCard;
 			sourceTree = "<group>";
 		};
-		735EE1AD2AC0274400AD8B8D /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Frameworks;
-			sourceTree = "<unknown>";
-		};
 		7372274D2AD476960021EFC6 /* Component */ = {
 			isa = PBXGroup;
 			children = (
@@ -218,17 +209,7 @@
 			isa = PBXGroup;
 			children = (
 				737EE3522ABD646100D224FC /* Onbom */,
-				737EE3512ABD646100D224FC /* Products */,
-				735EE1AD2AC0274400AD8B8D /* Frameworks */,
 			);
-			sourceTree = "<group>";
-		};
-		737EE3512ABD646100D224FC /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				737EE3502ABD646100D224FC /* Onbom.app */,
-			);
-			name = Products;
 			sourceTree = "<group>";
 		};
 		737EE3522ABD646100D224FC /* Onbom */ = {
@@ -275,7 +256,6 @@
 				7372273D2AD2FB340021EFC6 /* MediHistoryView.swift */,
 				7372273F2AD30BBE0021EFC6 /* RejectView.swift */,
 				737227412AD323360021EFC6 /* PatientInfoView.swift */,
-				737227472AD475840021EFC6 /* TextFormView.swift */,
 				731609672AD838FB00399476 /* StepView.swift */,
 				735ADB2E2AD5AC4E0069B94B /* MediConditionView.swift */,
 			);
@@ -440,7 +420,7 @@
 				735EE1A22AC01BDE00AD8B8D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				739F9F9F2AC1DA0D00523110 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
 			);
-			productRefGroup = 737EE3512ABD646100D224FC /* Products */;
+			productRefGroup = 737EE3472ABD646100D224FC;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (

--- a/Onbom/Onbom/Core/DigitalSignature/DigitalSignatureManager.swift
+++ b/Onbom/Onbom/Core/DigitalSignature/DigitalSignatureManager.swift
@@ -10,12 +10,16 @@ import SwiftUI
 class DigitalSignatureManager: ObservableObject {
     @Published var paths: [[CGPoint]] = []
     @Published var currentPath: [CGPoint] = []
-    let rectangle = Rectangle().path(in: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width-40, height: 250))
-    
+    @Published var isStart = false
+    let rectangle = Rectangle().path(in: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width-40, height: 146))
+
     func gesture() -> some Gesture {
         DragGesture()
             .onChanged { value in
                 if self.rectangle.contains(value.location) {
+                    if !self.isStart {
+                        self.isStart = true
+                        }
                     self.addNewCurrentPath(value)
                 }
             }

--- a/Onbom/Onbom/Core/PDF/PDFManager.swift
+++ b/Onbom/Onbom/Core/PDF/PDFManager.swift
@@ -13,7 +13,7 @@ class PDFManager: ObservableObject {
     let cgRectArray: [CGRect] = [CGRect(x: 150, y: 650, width: 140, height: 20),CGRect(x: 350, y: 650, width: 140, height: 20),CGRect(x: 150, y: 600, width: 140, height: 20),CGRect(x: 350, y: 565, width: 140, height: 20)]
     let signatureRect: CGRect = CGRect(x: 300, y: 300, width: 500, height: 250)
     
-    func createPDF(documentURL: URL, newText: [String], signature: [[CGPoint]]) {
+    func createPDF(documentURL: URL, newText: [String], signature: [[CGPoint]], image: UIImage, imageSize: CGSize) {
         guard let pdfDocument = PDFDocument(url: documentURL) else { return }
         
         if let firstPage = pdfDocument.page(at: 0) {
@@ -28,11 +28,13 @@ class PDFManager: ObservableObject {
         }
         
         addSignatureToPDF(lines: signature, pdfDocument: pdfDocument)
+        addIDCardToPDF(pdfDocument: pdfDocument, image: image, imageSize: imageSize)
         
         guard let newData = pdfDocument.dataRepresentation() else { return }
         PDFDatas.append(newData)
     }
     
+    // MARK: 전자서명 추가하는 함수
     func addSignatureToPDF(lines: [[CGPoint]], pdfDocument: PDFDocument) {
         if let secondPage = pdfDocument.page(at: 1) {
             for line in lines {
@@ -40,7 +42,6 @@ class PDFManager: ObservableObject {
                 linePath.lineWidth = 20
                 
                 guard !line.isEmpty else { continue }
-                // 좌표를 상하반전해서 적용
                 let reversedLine = line.map { CGPoint(x: $0.x, y: signatureRect.height - $0.y) }
                 linePath.move(to: reversedLine[0])
                 
@@ -53,6 +54,27 @@ class PDFManager: ObservableObject {
                 secondPage.addAnnotation(lineAnnotation)
             }
         }
+    }
+    
+    // MARK: 민증 사진 추가하는 함수
+    func addIDCardToPDF(pdfDocument: PDFDocument, image: UIImage, imageSize: CGSize) {
+        let page = PDFPage()
+        let a4Bounds = CGRect(x: 0, y: 0, width: 595.2, height: 841.8)
+        page.setBounds(a4Bounds, for: .cropBox)
+        let renderer = UIGraphicsImageRenderer(size: a4Bounds.size)
+        let img = renderer.image { context in
+            context.cgContext.saveGState()
+            context.cgContext.translateBy(x: 0, y: a4Bounds.height)
+            page.draw(with: .mediaBox, to: context.cgContext)
+            context.cgContext.restoreGState()
+            
+            let myImage = image
+            // 이미지의 위치와 크기 지정하는 코드
+            myImage.draw(in: CGRect(x: (a4Bounds.width - imageSize.width * 10) / 2, y: (a4Bounds.height - imageSize.height * 10) / 2, width: imageSize.width*10, height: imageSize.height*10))
+        }
+
+        let newPage = PDFPage(image: img)!
+        pdfDocument.insert(newPage, at: 2)
     }
 
 }

--- a/Onbom/Onbom/View/AgentInfo/AgentInfoDetailView.swift
+++ b/Onbom/Onbom/View/AgentInfo/AgentInfoDetailView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct AgentInfoDetailView: View {
-    @State private var isShowSheet = false
     var body: some View {
         VStack(alignment: .leading, spacing: 45) {
             Text("상세 관계를 모르겠어요")
@@ -51,19 +50,9 @@ struct AgentInfoDetailView: View {
             .frame(maxWidth: .infinity)
             .background(RoundedRectangle(cornerRadius: 12).fill(Color.G2))
             .onTapGesture {
-                isShowSheet = true
-            }
-            .confirmationDialog("타이틀", isPresented: $isShowSheet) {
-                Button {
-                    // 통화 기능 추가 예정
-                } label: {
-                    HStack {
-                        // TODO: Dialog에 Image가 안나오는 이슈 있음. -> 커스텀하거나 UIKit 써야하는 듯
-                        Image(systemName: "phone.fill")
-                        Text("통화 1577-1000")
-                    }
+                if let url = URL(string: "tel://15771000") {
+                    UIApplication.shared.open(url)
                 }
-                Button("취소", role: .cancel) {}
             }
             Spacer()
         }

--- a/Onbom/Onbom/View/AgentInfo/AgentInfoDetailView.swift
+++ b/Onbom/Onbom/View/AgentInfo/AgentInfoDetailView.swift
@@ -8,8 +8,66 @@
 import SwiftUI
 
 struct AgentInfoDetailView: View {
+    @State private var isShowSheet = false
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack(alignment: .leading, spacing: 45) {
+            Text("상세 관계를 모르겠어요")
+                .H2()
+                .foregroundColor(.B)
+            VStack(alignment: .leading, spacing: 12 ) {
+                Text("가족")
+                    .T2()
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("•  배우자, 직계혈족 및 형제자매")
+                        .Cap1()
+                    Text("•  직게혈족의 배우자")
+                        .Cap1()
+                    Text("•  배우자의 직계혈족,배우자의 형제자매")
+                        .Cap1()
+                }
+                .padding(.leading, 10)
+                Text("친족")
+                    .T2()
+                    .padding(.top, 40)
+                Text("•  8촌 이내의 혈족 및 4촌 이내 인척")
+                    .Cap1()
+            }
+            .foregroundColor(.G6)
+            HStack {
+                VStack {
+                    Text("국민건강보험공단 고객센터")
+                        .B1()
+                        .padding(.bottom, 1)
+                    Text("기타 문의가 필요하신 경우")
+                        .B3()
+                }
+                .foregroundColor(.G5)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .foregroundColor(.G4)
+            }
+            .padding(20)
+            .frame(height: 86)
+            .frame(maxWidth: .infinity)
+            .background(RoundedRectangle(cornerRadius: 12).fill(Color.G2))
+            .onTapGesture {
+                isShowSheet = true
+            }
+            .confirmationDialog("타이틀", isPresented: $isShowSheet) {
+                Button {
+                    // 통화 기능 추가 예정
+                } label: {
+                    HStack {
+                        // TODO: Dialog에 Image가 안나오는 이슈 있음. -> 커스텀하거나 UIKit 써야하는 듯
+                        Image(systemName: "phone.fill")
+                        Text("통화 1577-1000")
+                    }
+                }
+                Button("취소", role: .cancel) {}
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 20)
     }
 }
 

--- a/Onbom/Onbom/View/DigitalSignature/SignatureView.swift
+++ b/Onbom/Onbom/View/DigitalSignature/SignatureView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct SignatureView: View {
     @ObservedObject var digitalSignatureManager = DigitalSignatureManager()
-    
     var body: some View {
         VStack(alignment: .leading) {
             Text("서명을 해주세요")
@@ -24,18 +23,30 @@ struct SignatureView: View {
                     .cornerRadius(10)
                 ForEach(digitalSignatureManager.paths.indices, id: \.self) { index in
                     DrawLine(currentPath: digitalSignatureManager.paths[index])
-                        .stroke(style: StrokeStyle(lineWidth: 10, lineCap: .round))
-                        .foregroundColor(.blue)
+                        .stroke(style: StrokeStyle(lineWidth: 5, lineCap: .round))
+                        .foregroundColor(.B)
                 }
                 DrawLine(currentPath: digitalSignatureManager.currentPath)
-                    .stroke(style: StrokeStyle(lineWidth: 10, lineCap: .round))
-                    .foregroundColor(.blue)
+                    .stroke(style: StrokeStyle(lineWidth: 5, lineCap: .round))
+                    .foregroundColor(.B)
             }
-            .overlay(alignment: .topTrailing) {
-                deleteButton
-                    .padding(20)
+            .overlay {
+                if digitalSignatureManager.isStart {
+                    VStack {
+                        HStack {
+                            Spacer()
+                            deleteButton
+                                .padding(20)
+                        }
+                        Spacer()
+                    }
+                } else {
+                    Text("서명을 입력해 주세요")
+                        .Cap2()
+                        .foregroundColor(.G4)
+                }
             }
-            .frame(height: 250)
+            .frame(height: 146)
             .gesture(digitalSignatureManager.gesture())
             Spacer()
             Button("완료") {

--- a/Onbom/Onbom/View/DigitalSignature/TempWriteSignatureView.swift
+++ b/Onbom/Onbom/View/DigitalSignature/TempWriteSignatureView.swift
@@ -50,7 +50,7 @@ struct TempWriteSignatureView: View {
     
     func completeForm() {
         guard !answerInputs.contains(where: { $0.isEmpty }) else { return }
-        pdfManager.createPDF(documentURL: LTCIFormResource, newText: answerInputs, signature: digitalSignatureManager.paths)
+        pdfManager.createPDF(documentURL: LTCIFormResource, newText: answerInputs, signature: digitalSignatureManager.paths, image: UIImage(systemName: "person.text.rectangle")!, imageSize: UIImage(systemName: "person.text.rectangle")!.size)
     }
 }
 

--- a/Onbom/Onbom/View/Form/TempPDFView.swift
+++ b/Onbom/Onbom/View/Form/TempPDFView.swift
@@ -23,7 +23,9 @@ struct TempPDFView: View {
                         PDFViewer(pdfData: pdfdata)
                     } label: {
                         Text("PDF 보기 \(index)")
-                    }.padding()
+                    }
+                    .padding()
+                    .foregroundColor(.red)
                 }
                 Text("신청한 수 : \(pdfManager.PDFDatas.count)")
                     .padding()


### PR DESCRIPTION
## 🔥 *Pull requests*

## ⛳️ **작업한 브랜치**
- #49 

## 👷 **작업한 내용**
- 클론하면서 생긴 Products 폴더와 Frameworks 폴더 삭제
- `AgentInfoDetailView` 구현 + 국민건강보험공단 통화 기능 추가(실기기에서만 확인 가능)
- `PDFManager`안에 기존 pdf에 새페이지를 생성해서 사진을 추가할 수 있는 `addIDCardToPDF` 함수 추가
- `SignatureView` 디자인 디테일 수정
    - 제스처 시작 전엔 텍스트 보임 -> 제스처 시작한 이후 삭제 버튼 보임

## 🚨 참고 사항
#### A4용지 안에서의 위치와 크기를 지정하는 코드
```swift
myImage.draw(in: CGRect(x: (a4Bounds.width - imageSize.width * 10) / 2, y: (a4Bounds.height - imageSize.height * 10) / 2, width: imageSize.width*10, height: imageSize.height*10))
```
민증 사진 크기가 정확히 어떻게 되고 pdf 상에서는 어떻게 보일지 몰라서 일단 파라미터로 받게 함.
**현재는 SF Symbol를 이미지 대신 넣은거라 크기를 10배 뻥튀기 했음.**

## 📸 스크린샷
|AgentInfoDetailView|addIDCardToPDF|SignatureView|
|:--:|:--:|:--:|
|<img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team2-Nutty/assets/102914072/9a7ef07c-71cc-43ae-841f-62495f5ab11b" width="300" />|![ezgif com-gif-maker (1)](https://github.com/DeveloperAcademy-POSTECH/MacC-Team2-Nutty/assets/102914072/8dc48f61-3d8a-48ac-90ee-686ce3e7abd2)|![Simulator Screen Recording - iPhone 14 - 2023-10-17 at 13 25 22](https://github.com/DeveloperAcademy-POSTECH/MacC-Team2-Nutty/assets/102914072/d07e1419-50b6-4efb-96dd-3511e877988f)|




## 📟 관련 이슈
- Resolved: #
