### PR TITLE
104 connect edit page in submitview and update detail

### DIFF
--- a/Onbom/Onbom/Components/Alert.swift
+++ b/Onbom/Onbom/Components/Alert.swift
@@ -19,9 +19,9 @@ struct Alert: View {
             HStack {
                 Image(image)
                 Text(label)
-                    .Cap5()
+                    .Cap4()
             }
-            .padding(13)
+            .padding(10)
         }
     }
 }

--- a/Onbom/Onbom/Components/CityAddressInputField.swift
+++ b/Onbom/Onbom/Components/CityAddressInputField.swift
@@ -19,7 +19,7 @@ struct CityAddressInputField: View {
             Text(label)
                 .foregroundColor(titleFocused ? .Green4 : .G6)
                 .Label()
-            
+                .padding(.bottom, 4)
             TextField(placeholder, text: $content)
                 .focused($isFocused)
                 .padding()

--- a/Onbom/Onbom/Components/FormTextField.swift
+++ b/Onbom/Onbom/Components/FormTextField.swift
@@ -26,7 +26,7 @@ struct FormTextField: View {
                 .foregroundColor(focused ? Color.Green4 : Color.G6)
                 .Label()
                 .frame(maxWidth: .infinity, alignment: .leading)
-            
+                .padding(.bottom, 4)
             TextField(placeHolder, text: $textInput)
                 .font(.custom("Pretendard-Medium", size: 16))
                 .lineSpacing(16 / 2 * (100 - 100)/100)

--- a/Onbom/Onbom/Components/InputField.swift
+++ b/Onbom/Onbom/Components/InputField.swift
@@ -12,7 +12,6 @@ struct InputField: View {
     var buttonAction: (() -> Void)?
     var placeholder: String
     @Binding var content: String
-    // TODO: 다른 곳을 탭했을 때, isFocused가 false 되야 하는데 이건 추후에 다시 좀 해야할듯
     @FocusState var isFocused: Bool
     
     var body: some View {

--- a/Onbom/Onbom/Components/NumberInputField.swift
+++ b/Onbom/Onbom/Components/NumberInputField.swift
@@ -20,7 +20,7 @@ struct NumberInputField: View {
             Text(label)
                 .foregroundColor(isFocused ? .Green4 : .G6)
                 .Label()
-
+                .padding(.bottom, 4)
             inputField
                 .focused($isFocused)
                 .padding()

--- a/Onbom/Onbom/Components/RadioButton.swift
+++ b/Onbom/Onbom/Components/RadioButton.swift
@@ -51,8 +51,8 @@ public struct RadioButtonStyleModifiers: ButtonStyle {
             configuration.label
                 .foregroundColor(configuration.isPressed ? Color.Green4 : .B)
                 .frame(maxWidth: .infinity)
+                .frame(height: 100)
                 .padding(.leading, 20.0)
-                .padding(.vertical, 22)
                 .background(RoundedRectangle(cornerRadius: 10).fill(configuration.isPressed ? Color.Green3 : Color.G2))
                 .foregroundColor(configuration.isPressed ? .Green4 : .B)
                 .overlay(RoundedRectangle(cornerRadius: 16)
@@ -62,8 +62,8 @@ public struct RadioButtonStyleModifiers: ButtonStyle {
             configuration.label
                 .foregroundColor(Color.Green4)
                 .frame(maxWidth: .infinity)
+                .frame(height: 100)
                 .padding(.leading, 20.0)
-                .padding(.vertical, 22)
                 .background(RoundedRectangle(cornerRadius: 10).fill(Color.Green2))
                 .foregroundColor(configuration.isPressed ? .Green4 : .B)
                 .overlay(RoundedRectangle(cornerRadius: 16)

--- a/Onbom/Onbom/Core/DigitalSignature/DigitalSignatureManager.swift
+++ b/Onbom/Onbom/Core/DigitalSignature/DigitalSignatureManager.swift
@@ -11,7 +11,7 @@ class DigitalSignatureManager: ObservableObject {
     @Published var paths: [[CGPoint]] = []
     @Published var currentPath: [CGPoint] = []
     @Published var isStart = false
-    let rectangle = Rectangle().path(in: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width-40, height: 146))
+    let rectangle = Rectangle().path(in: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width-40, height: 180))
 
     func gesture() -> some Gesture {
         DragGesture()

--- a/Onbom/Onbom/Core/PDF/PDFManager.swift
+++ b/Onbom/Onbom/Core/PDF/PDFManager.swift
@@ -15,7 +15,6 @@ class PDFManager: ObservableObject {
     let imageSizeFloat: CGFloat = 0.5
     enum FixedPositionItems: CaseIterable {
             case apply
-            case protector
             case mailReceive
             case mailAddress
             case todayDate
@@ -32,8 +31,6 @@ class PDFManager: ObservableObject {
                 switch item {
                 case .apply:
                     addTextAnnotation(page: firstPage, bounds: CGRect(x: 168, y: 742, width: 140, height: 20), content: "✓")
-                case .protector:
-                    addTextAnnotation(page: firstPage, bounds:CGRect(x: 378, y: 208, width: 140, height: 20), content: "✓")
                 default:
                     continue
                 }

--- a/Onbom/Onbom/Core/ViewModel/HomeNavigationViewModel.swift
+++ b/Onbom/Onbom/Core/ViewModel/HomeNavigationViewModel.swift
@@ -27,7 +27,13 @@ class HomeNavigationViewModel: ObservableObject{
     }
     
     func popToRoot() {
-        homePath = []
+        DispatchQueue.main.async {
+            var transaction = Transaction()
+            transaction.disablesAnimations = true
+            let _ = withTransaction(transaction) {
+                self.homePath.removeAll()
+            }
+        }
     }
 }
 

--- a/Onbom/Onbom/View/Donghaeng/CallTaxiView.swift
+++ b/Onbom/Onbom/View/Donghaeng/CallTaxiView.swift
@@ -14,18 +14,18 @@ struct CallTaxiView: View {
         VStack {
             Text("포항시 동행콜 배차신청하기")
                 .H1()
-                .foregroundColor(.G6)
+                .foregroundStyle(Color.G6)
                 .padding(.bottom, 10)
             Text("어쩌구 전화로 신청할까요?")
                 .Cap2()
-                .foregroundColor(.G4)
+                .foregroundStyle(Color.G4)
                 .padding(.bottom)
             Spacer()
             Image("CallTaxi")
             Spacer()
             Text("•  통화 전 어쩌구 저쩌구 시간과 장소를\n•  미리 생각해주세요")
                 .Cap3()
-                .foregroundColor(.G5)
+                .foregroundStyle(Color.G5)
                 .padding(.bottom, 50)
             CTAButton.CustomButtonView(
                 style: .primary(isDisabled: false))
@@ -79,7 +79,7 @@ struct CallTaxiModalView: View {
                 .padding(.bottom, 18)
             Text("지금은 콜센터 운영 시간이 아니에요")
                 .T1()
-                .foregroundColor(.B)
+                .foregroundStyle(Color.B)
                 .padding(.bottom, 20)
             VStack(alignment: .leading, spacing: 3) {
                 Text("•  평 일 : 오전 7시 부터 오후 10시")
@@ -89,11 +89,11 @@ struct CallTaxiModalView: View {
                 Text("•  일 · 공휴일 : 오전 7시 부터 오후 4시")
                     .Cap3()
             }
-            .foregroundColor(.G5)
+            .foregroundStyle(Color.G5)
             .padding(.bottom)
             Text("콜센터 운영 시간이 되면 알림을 보내드릴까요?")
                 .Cap3()
-                .foregroundColor(.G5)
+                .foregroundStyle(Color.G5)
             Spacer()
             HStack {
                 CTAButton.CustomButtonView(style: .secondary) {

--- a/Onbom/Onbom/View/LTCI/Address/AddressFormView.swift
+++ b/Onbom/Onbom/View/LTCI/Address/AddressFormView.swift
@@ -144,7 +144,7 @@ struct AddressFormView: View {
                     .padding(.top, 34)
                 
                 Text("작성하신 주민등록지가 현재\n어르신이 머무르고 계신 곳인가요?")
-                    .T2()
+                    .T1()
                     .foregroundColor(.B)
                     .multilineTextAlignment(.center)
                     .padding(20)

--- a/Onbom/Onbom/View/LTCI/Address/AddressFormView.swift
+++ b/Onbom/Onbom/View/LTCI/Address/AddressFormView.swift
@@ -158,7 +158,7 @@ struct AddressFormView: View {
                 HStack(spacing: 10) {
                     CTAButton.CustomButtonView(style: .secondary) {
                         patient.address = address
-                        patient.actualAddress = address
+//                        patient.actualAddress = address
                         hideKeyboard()
                         showActualAddressCheckView = false
                         homeNavigation.navigate(.StepView_Second)

--- a/Onbom/Onbom/View/LTCI/Address/AddressFormView.swift
+++ b/Onbom/Onbom/View/LTCI/Address/AddressFormView.swift
@@ -84,7 +84,6 @@ struct AddressFormView: View {
                 .padding(20)
                 
                 ScrollView {
-                    
                     if formType != .agent {
                         Alert(image: "check", label: alertMessage)
                             .padding([.bottom, .trailing, .leading], 20)
@@ -141,13 +140,13 @@ struct AddressFormView: View {
         .sheet(isPresented: $showActualAddressCheckView) {
             VStack(spacing: 0){
                 Image("warning")
-                    .padding(.top, 34)
+                    .padding(.top, 30)
                 
                 Text("작성하신 주민등록지가 현재\n어르신이 머무르고 계신 곳인가요?")
                     .T1()
                     .foregroundColor(.B)
                     .multilineTextAlignment(.center)
-                    .padding(20)
+                    .padding(.vertical, 20)
                 
                 Text("어르신이 병원이나 자녀 집 등 다른 곳에 계시다면\n추가 입력이 필요해요.")
                     .Cap3()
@@ -177,7 +176,6 @@ struct AddressFormView: View {
                     }
                 }
                 .padding(.horizontal)
-                .padding(.top, 34)
             }
             .presentationDetents([.fraction(0.43)])
             .presentationDragIndicator(.hidden)

--- a/Onbom/Onbom/View/LTCI/Address/AddressFormView.swift
+++ b/Onbom/Onbom/View/LTCI/Address/AddressFormView.swift
@@ -77,7 +77,7 @@ struct AddressFormView: View {
             VStack(spacing: 0) {
                 HStack {
                     Text(titleMessage)
-                        .H2()
+                        .H1()
                         .foregroundColor(.B)
                     Spacer()
                 }

--- a/Onbom/Onbom/View/LTCI/AgentInfo/AgentInfoDetailView.swift
+++ b/Onbom/Onbom/View/LTCI/AgentInfo/AgentInfoDetailView.swift
@@ -11,7 +11,7 @@ struct AgentInfoDetailView: View {
     var body: some View {
         VStack(alignment: .leading) {
             Text("상세 관계를 모르겠어요")
-                .H2()
+                .H1()
                 .foregroundColor(.B)
                 .padding(.bottom, 54)
             

--- a/Onbom/Onbom/View/LTCI/AgentInfo/AgentInfoView.swift
+++ b/Onbom/Onbom/View/LTCI/AgentInfo/AgentInfoView.swift
@@ -18,7 +18,7 @@ struct AgentInfoView: View {
     var body: some View {
         VStack(alignment: .leading) {
             Text("\(agent.name)님과 \(patient.name)님의\n상세 관계를 선택해 주세요")
-                .H2()
+                .H1()
                 .foregroundColor(Color.B)
                 .padding(.bottom, 48)
             Text("상세 관계")

--- a/Onbom/Onbom/View/LTCI/AgentInfo/AgentInfoView.swift
+++ b/Onbom/Onbom/View/LTCI/AgentInfo/AgentInfoView.swift
@@ -24,6 +24,7 @@ struct AgentInfoView: View {
             Text("상세 관계")
                 .Label()
                 .foregroundColor(Color.G6)
+                .padding(.bottom, 4)
             HStack {
                 ForEach(0..<2, id: \.self) { index in
                     let twoStyle: RadioButtonStyle = twoSelectedIndex == index ? .twoSelected : .twoUnselected

--- a/Onbom/Onbom/View/LTCI/ApplyTypeView.swift
+++ b/Onbom/Onbom/View/LTCI/ApplyTypeView.swift
@@ -39,13 +39,13 @@ struct ApplyTypeView: View {
                                 VStack(alignment: .leading, spacing: 13) {
                                     if index == 0 {
                                         Text("\(title[index])")
-                                            .T3()
+                                            .T2()
                                         Text("\(description[index])")
                                             .Cap3()
                                     }
                                     else {
                                         Text("\(title[index])")
-                                            .T3()
+                                            .T2()
                                         // 비활성화 후 텍스트 색상 임시 변경
                                             .foregroundColor(.G3)
                                         Text("\(description[index])")

--- a/Onbom/Onbom/View/LTCI/ApplyTypeView.swift
+++ b/Onbom/Onbom/View/LTCI/ApplyTypeView.swift
@@ -21,7 +21,7 @@ struct ApplyTypeView: View {
         ZStack {
             VStack {
                 Text("장기요양등급\n신청 종류를 선택해 주세요")
-                    .H2()
+                    .H1()
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.bottom, 48)
                 

--- a/Onbom/Onbom/View/LTCI/IDCard/IDCardConfirmEditView.swift
+++ b/Onbom/Onbom/View/LTCI/IDCard/IDCardConfirmEditView.swift
@@ -22,7 +22,7 @@ struct IDCardConfirmEditView: View {
         VStack {
             HStack {
                 Text("신분증 정보를 확인해 주세요")
-                    .H2()
+                    .H1()
                     .foregroundColor(.B)
                 Spacer()
             }

--- a/Onbom/Onbom/View/LTCI/IDCard/IDCardDescriptionView.swift
+++ b/Onbom/Onbom/View/LTCI/IDCard/IDCardDescriptionView.swift
@@ -17,7 +17,7 @@ struct IDCardDescriptionView: View {
         VStack {
             HStack {
                 Text("\(name)님의 신분증을\n촬영할 수 있도록 준비해 주세요")
-                    .H2()
+                    .H1()
                     .foregroundColor(.B)
                     .padding(.bottom, 20)
                 Spacer()

--- a/Onbom/Onbom/View/LTCI/MediConditionView.swift
+++ b/Onbom/Onbom/View/LTCI/MediConditionView.swift
@@ -16,7 +16,7 @@ struct MediConditionView: View {
     var body: some View {
         VStack(spacing: 0){
             Text("어르신이 현재 전염성 질병 또는\n정신질환을 가지고 계신가요?")
-                .H2()
+                .H1()
                 .foregroundColor(Color.B)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.bottom, 48)

--- a/Onbom/Onbom/View/LTCI/MediConditionView.swift
+++ b/Onbom/Onbom/View/LTCI/MediConditionView.swift
@@ -58,6 +58,7 @@ struct AlternativeForm: View {
                 .Label()
                 .foregroundColor(Color.G6)
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.bottom, 4)
             HStack(spacing: 10) {
                 RadioButton.CustomButtonView(style: isCheckedYES() ? .twoSelected : .twoUnselected) {
                         answer = true

--- a/Onbom/Onbom/View/LTCI/MediHistoryView.swift
+++ b/Onbom/Onbom/View/LTCI/MediHistoryView.swift
@@ -13,9 +13,9 @@ struct MediHistoryView: View {
     var body: some View {
         //TODO: - Gradient 배경 빠져 있음
         VStack {
-            Text("어르신이 3개월 내\n입원 또는 수술 이력이 있으신가요?")
+            Text("어르신이 3개월 내 입원 또는\n수술 이력이 있으신가요?")
                 .foregroundColor(Color.B)
-                .H2()
+                .H1()
                 .frame(maxWidth: .infinity, alignment: .leading)
             Spacer()
             Image("MediHistoryImage")

--- a/Onbom/Onbom/View/LTCI/PatientInfoView.swift
+++ b/Onbom/Onbom/View/LTCI/PatientInfoView.swift
@@ -31,7 +31,7 @@ struct PatientInfoView: View {
     var body: some View {
         VStack(spacing: 0) {
             Text(step[1] == false ? "어르신의\n성함을 입력해주세요" : viewModel.seniorName + getTitle())
-                .H2()
+                .H1()
                 .foregroundColor(Color.B)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, 20)

--- a/Onbom/Onbom/View/LTCI/PrivacyPolicyView.swift
+++ b/Onbom/Onbom/View/LTCI/PrivacyPolicyView.swift
@@ -63,7 +63,7 @@ struct PrivacyPolicyView: View {
                 .frame(width: 20)
                 .foregroundColor(isAllCheck ? .Green4 : .G3)
             Text("개인정보 처리에 모두 동의합니다.")
-                .H2()
+                .T1()
                 .foregroundColor(.B)
             Spacer()
         }.onTapGesture {

--- a/Onbom/Onbom/View/LTCI/RejectView.swift
+++ b/Onbom/Onbom/View/LTCI/RejectView.swift
@@ -14,7 +14,7 @@ struct RejectView: View {
         VStack(spacing: 0) {
             Text("지금은 어르신의 등급심사가 어려워요")
                 .foregroundColor(Color.B)
-                .H2()
+                .H1()
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.bottom, 21)
             VStack {

--- a/Onbom/Onbom/View/LTCI/SignatureView.swift
+++ b/Onbom/Onbom/View/LTCI/SignatureView.swift
@@ -16,7 +16,7 @@ struct SignatureView: View {
     var body: some View {
         VStack(alignment: .leading) {
             Text("서명을 해주세요")
-                .H2()
+                .H1()
             Alert(image: "security", label: "입력한 서명은 저장되지 않으니 안심하세요")
                 .padding(.vertical, 8)
                 .padding(.bottom, 30)

--- a/Onbom/Onbom/View/LTCI/SignatureView.swift
+++ b/Onbom/Onbom/View/LTCI/SignatureView.swift
@@ -23,6 +23,7 @@ struct SignatureView: View {
             Text("대리인 본인")
                 .Label()
                 .foregroundColor(Color.G6)
+                .padding(.bottom, 4)
             ZStack {
                 digitalSignatureManager.rectangle
                     .fill(Color.G2)

--- a/Onbom/Onbom/View/LTCI/SignatureView.swift
+++ b/Onbom/Onbom/View/LTCI/SignatureView.swift
@@ -53,7 +53,7 @@ struct SignatureView: View {
                         .foregroundColor(.G4)
                 }
             }
-            .frame(height: 146)
+            .frame(height: 180)
             .gesture(digitalSignatureManager.gesture())
             Spacer()
             CTAButton.CustomButtonView(

--- a/Onbom/Onbom/View/LTCI/StepView.swift
+++ b/Onbom/Onbom/View/LTCI/StepView.swift
@@ -31,12 +31,12 @@ struct StepView: View {
                 .padding(.bottom, 10)
             if state == .FIRST {
                 Text("신청대상자의 정보부터\n확인할게요")
-                    .H2()
+                    .H1()
                 .foregroundColor(.B)
                 .padding(.bottom, 32)
             } else {
                 Text("대리인 김유진님의 정보를 \n확인할게요")
-                    .H2()
+                    .H1()
                 .foregroundColor(.B)
                 .padding(.bottom, 32)
             }

--- a/Onbom/Onbom/View/LTCI/SubmitCheckListView.swift
+++ b/Onbom/Onbom/View/LTCI/SubmitCheckListView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct SubmitCheckListView: View {
-//    @EnvironmentObject var homeNavigation: HomeNavigationViewModel
+    //    @EnvironmentObject var homeNavigation: HomeNavigationViewModel
     @EnvironmentObject var patient: Patient
     @EnvironmentObject var agent: Agent
     @EnvironmentObject var pdfManager: PDFManager
@@ -18,7 +18,7 @@ struct SubmitCheckListView: View {
     var body: some View {
         HStack {
             Text("신청 정보를 확인해 주세요")
-                .H2()
+                .H1()
                 .foregroundColor(.B)
             Spacer()
         }
@@ -245,22 +245,23 @@ struct SubmitCheckListView: View {
         }
         .padding(.bottom,0)
         .padding([.top, .leading, .trailing], 20)
-//
-//        Button {
-//
-//        } label: {
-//            Text("신청하기")
-//                .foregroundColor(Color.white)
-//                .B1()
-//                .padding(.vertical, 20)
-//                .frame(maxWidth: .infinity)
-//        }
-//        .background(RoundedRectangle(cornerRadius: 16).fill(Color.PB4))
-//        .padding()
+        //
+        //        Button {
+        //
+        //        } label: {
+        //            Text("신청하기")
+        //                .foregroundColor(Color.white)
+        //                .B1()
+        //                .padding(.vertical, 20)
+        //                .frame(maxWidth: .infinity)
+        //        }
+        //        .background(RoundedRectangle(cornerRadius: 16).fill(Color.PB4))
+        //        .padding()
         .navigationBarBackButton()
         .navigationDestination(isPresented: $isSubmitLoadingViewPresented) {
             SubmitLoadingView()
         }
+        
     }
 }
 

--- a/Onbom/Onbom/View/LTCI/SubmitCheckListView.swift
+++ b/Onbom/Onbom/View/LTCI/SubmitCheckListView.swift
@@ -8,11 +8,9 @@
 import SwiftUI
 
 struct SubmitCheckListView: View {
-    //    @EnvironmentObject var homeNavigation: HomeNavigationViewModel
     @EnvironmentObject var patient: Patient
     @EnvironmentObject var agent: Agent
     @EnvironmentObject var pdfManager: PDFManager
-    
     @State private var isSubmitLoadingViewPresented = false
     
     var body: some View {
@@ -239,29 +237,22 @@ struct SubmitCheckListView: View {
         CTAButton.CustomButtonView(
             style: .primary(isDisabled:false))
         {
-            isSubmitLoadingViewPresented = true
+            var transaction = Transaction()
+            transaction.disablesAnimations = true
+            withTransaction(transaction) {
+                isSubmitLoadingViewPresented = true
+            }
+            
         } label: {
             Text("신청하기")
         }
         .padding(.bottom,0)
         .padding([.top, .leading, .trailing], 20)
-        //
-        //        Button {
-        //
-        //        } label: {
-        //            Text("신청하기")
-        //                .foregroundColor(Color.white)
-        //                .B1()
-        //                .padding(.vertical, 20)
-        //                .frame(maxWidth: .infinity)
-        //        }
-        //        .background(RoundedRectangle(cornerRadius: 16).fill(Color.PB4))
-        //        .padding()
         .navigationBarBackButton()
-        .navigationDestination(isPresented: $isSubmitLoadingViewPresented) {
-            SubmitLoadingView()
+        .fullScreenCover(isPresented: $isSubmitLoadingViewPresented) {
+            SubmitView()
+            
         }
-        
     }
 }
 

--- a/Onbom/Onbom/View/LTCI/SubmitLoadingView.swift
+++ b/Onbom/Onbom/View/LTCI/SubmitLoadingView.swift
@@ -12,11 +12,11 @@ struct SubmitLoadingView: View {
     
     var body: some View {
         VStack {
-            Text("국민건강보험공단에 보내고 있어요")
-                .H2()
+            Text("국민건강보험공단에\n보내고 있어요")
+                .H1()
                 .foregroundColor(.B)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.bottom, 162)
+                .padding(.bottom, 100)
                 .padding(.top, 45)
             Image("SubmitLoadingView")
     

--- a/Onbom/Onbom/View/LTCI/SubmitLoadingView.swift
+++ b/Onbom/Onbom/View/LTCI/SubmitLoadingView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct SubmitLoadingView: View {
-    @State private var isSubmitViewPresented = false
     
     var body: some View {
         VStack {
@@ -22,17 +21,8 @@ struct SubmitLoadingView: View {
     
             Spacer()
         }
-        .navigationDestination(isPresented: $isSubmitViewPresented, destination: {
-            SubmitView()
-        })
         .navigationBarBackButtonHidden(true)
-
         .padding(20.0)
-        .onAppear() {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                isSubmitViewPresented = true
-            }
-        }
     }
 }
 

--- a/Onbom/Onbom/View/LTCI/SubmitView.swift
+++ b/Onbom/Onbom/View/LTCI/SubmitView.swift
@@ -12,50 +12,66 @@ struct SubmitView: View {
     @EnvironmentObject var patient: Patient
     @EnvironmentObject var agent: Agent
     @EnvironmentObject var pdfManager: PDFManager
+    @State private var isloadingViewPresented = true
     
     var body: some View {
-        VStack {
-            VStack(spacing: 20) {
-                Text("신청 끝!\n약 2주 후 방문 조사가 있어요")
-                    .H1()
-                    .lineSpacing(10)
-                    .foregroundColor(.B)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.top, 40)
-                Text("어르신 방문을 위해 건강보험공단에서 연락을 할 거예요\n등급 산정 과정에서 추가 서류가 필요할 수도 있어요")
-                    .Cap3()
-                    .lineSpacing(10)
-                    .foregroundColor(.G5)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            .frame(maxHeight: .infinity, alignment: .topLeading)
-            .padding(.bottom, 71)
-            Image("SubmitView")
-                .padding(.bottom, 90)
-            VStack(spacing: 0) {
-                CTAButton.CustomButtonView(
-                    style: .primary(isDisabled: false))
-                {
-                    patient.updateDictionary()
-                    agent.updateDictionary()
-                    pdfManager.createPDF(documentURL: LTCIFormResource, patient: patient.dictionary, agent: agent.dictionary, signature: agent.signature, image: agent.idCardImage, imageSize: agent.idCardImage.size, infectious: patient.hasInfectiousDisease, mental: patient.hasMentalDisorder)
-                    homeNavigation.popToRoot()
-                } label: {
-                    Text("신청 완료")
+        if isloadingViewPresented {
+            SubmitLoadingView()
+                .onAppear {
+                    showLoadingView()
                 }
-                .padding(.bottom, 16)
-                Text("신청에 필요한 수수료는 온봄이 냈어요")
-                    .Label()
-                    .foregroundColor(.G4)
+        } else {
+            VStack {
+                VStack(spacing: 20) {
+                    Text("신청 끝!\n약 2주 후 방문 조사가 있어요")
+                        .H1()
+                        .lineSpacing(10)
+                        .foregroundColor(.B)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.top, 40)
+                    Text("어르신 방문을 위해 건강보험공단에서 연락을 할 거예요\n등급 산정 과정에서 추가 서류가 필요할 수도 있어요")
+                        .Cap3()
+                        .lineSpacing(10)
+                        .foregroundColor(.G5)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .frame(maxHeight: .infinity, alignment: .topLeading)
+                .padding(.bottom, 71)
+                Image("SubmitView")
+                    .padding(.bottom, 90)
+                VStack(spacing: 0) {
+                    CTAButton.CustomButtonView(
+                        style: .primary(isDisabled: false))
+                    {
+                        patient.updateDictionary()
+                        agent.updateDictionary()
+                        pdfManager.createPDF(documentURL: LTCIFormResource, patient: patient.dictionary, agent: agent.dictionary, signature: agent.signature, image: agent.idCardImage, imageSize: agent.idCardImage.size, infectious: patient.hasInfectiousDisease, mental: patient.hasMentalDisorder)
+                        homeNavigation.popToRoot()
+                    } label: {
+                        Text("신청 완료")
+                    }
+                    .padding(.bottom, 16)
+                    Text("신청에 필요한 수수료는 온봄이 냈어요")
+                        .Label()
+                        .foregroundColor(.G4)
+                }
             }
+            .navigationBarBackButtonHidden(true)
+            .padding([.top, .leading, .trailing], 20.0)
         }
-        .navigationBarBackButtonHidden(true)
-        .padding([.top, .leading, .trailing], 20.0)
+        
+    }
+    
+    func showLoadingView() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            isloadingViewPresented = false
+        }
     }
 }
 
 struct SubmitView_Previews: PreviewProvider {
     static var previews: some View {
         SubmitView()
+            .environmentObject(HomeNavigationViewModel())
     }
 }

--- a/Onbom/Onbom/View/LTCI/SubmitView.swift
+++ b/Onbom/Onbom/View/LTCI/SubmitView.swift
@@ -17,7 +17,7 @@ struct SubmitView: View {
         VStack {
             VStack(spacing: 20) {
                 Text("신청 끝!\n약 2주 후 방문 조사가 있어요")
-                    .H2()
+                    .H1()
                     .lineSpacing(10)
                     .foregroundColor(.B)
                     .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- #104

👷 **작업한 내용**
- 디자인 시스템 변경사항 적용
    - 라벨과 컴포넌트 사이 패딩 조정
    - 모달 타이틀
    - 라디오 버튼
    - 얼럿
- SignatureView 서명칸 높이 변경
- SubmitView에서 뒤로 가는 거 막기 (하지만 제출 후 메인화면으로 돌아갈때 모달이 닫히는(밑으로 내려가는) 모션이 있음)
- PDF에 '보호자 없음'에 체크되어 있던거 삭제
- 주소가 같은 경우에도 실주소지 값이 들어오던거 삭제

## 🚨 참고 사항
- `foregroundColor`는 deprecated 되었으니깐 `foregroundStyle`로 차차 변경하는 편이 좋지 않을까..
- 수정 기능은 디자인이 픽스되면 그때 다시 논의하기

## 📸 스크린샷
|SubmitView 제출 후 모션 존재|라디오 버튼|라벨과 컴포넌트 사이 패딩, 얼럿|모달 타이틀 크기|서명칸 높이|
|:--:|:--:|:--:|:--:|:--:|
|<img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team2-Nutty/assets/102914072/274661a2-dad3-43da-82c9-ed1cabcbc159" width="150">|![Simulator Screenshot - iPhone 14 - 2023-11-02 at 19 24 37](https://github.com/DeveloperAcademy-POSTECH/MacC-Team2-Nutty/assets/102914072/a5e49746-0300-4829-9a2c-778fedc24806)|![Simulator Screenshot - iPhone 14 - 2023-11-02 at 19 25 06](https://github.com/DeveloperAcademy-POSTECH/MacC-Team2-Nutty/assets/102914072/509874e2-d2e5-4675-9929-2d4e6662cb33)|![Simulator Screenshot - iPhone 14 - 2023-11-02 at 19 25 57](https://github.com/DeveloperAcademy-POSTECH/MacC-Team2-Nutty/assets/102914072/eb3059e6-0c67-44c2-bcb0-3cdd150e1927)|![Simulator Screenshot - iPhone 14 - 2023-11-02 at 19 28 02](https://github.com/DeveloperAcademy-POSTECH/MacC-Team2-Nutty/assets/102914072/e07b45de-5423-4a4e-9f46-22cc2fecb1b9)

## 📟 관련 이슈
- Resolved: #
