### PR TITLE
147 modify pdf signature size and add agentinfoview edit feature

### DIFF
--- a/Onbom/Onbom.xcodeproj/project.pbxproj
+++ b/Onbom/Onbom.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		AEB33E9E2AC40C470082A3E7 /* InputField.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB33E9D2AC40C470082A3E7 /* InputField.swift */; };
 		AEB33EA92ACAADE00082A3E7 /* PDFFormLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB33EA82ACAADE00082A3E7 /* PDFFormLocation.swift */; };
 		AEB33EAC2ACD3D010082A3E7 /* DigitalSignatureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB33EAB2ACD3D010082A3E7 /* DigitalSignatureManager.swift */; };
+		AEC6D9842B015BE700ED0E7C /* PrivacyPolicyDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC6D9832B015BE700ED0E7C /* PrivacyPolicyDetailView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -180,6 +181,7 @@
 		AEB33E9D2AC40C470082A3E7 /* InputField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputField.swift; sourceTree = "<group>"; };
 		AEB33EA82ACAADE00082A3E7 /* PDFFormLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFFormLocation.swift; sourceTree = "<group>"; };
 		AEB33EAB2ACD3D010082A3E7 /* DigitalSignatureManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DigitalSignatureManager.swift; sourceTree = "<group>"; };
+		AEC6D9832B015BE700ED0E7C /* PrivacyPolicyDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPolicyDetailView.swift; sourceTree = "<group>"; };
 		AEDB39752AE5BE6F0034E57E /* Dongle-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Dongle-Bold.ttf"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -377,6 +379,7 @@
 				AEA098F32AE6B13800DE9BA8 /* DescriptionView.swift */,
 				7337E1EE2AD1531700D91E6F /* ApplyTypeView.swift */,
 				AE10D3912AD4E1C900D9ED3C /* PrivacyPolicyView.swift */,
+				AEC6D9832B015BE700ED0E7C /* PrivacyPolicyDetailView.swift */,
 				731609672AD838FB00399476 /* StepView.swift */,
 				7372273D2AD2FB340021EFC6 /* MediHistoryView.swift */,
 				735ADB2E2AD5AC4E0069B94B /* MediConditionView.swift */,
@@ -694,6 +697,7 @@
 				70AC25AB2AF15CA300DBC4A0 /* DocumentDetector.swift in Sources */,
 				731EB7472AF9ED9A00931952 /* HomeViewModel.swift in Sources */,
 				AE10D3922AD4E1C900D9ED3C /* PrivacyPolicyView.swift in Sources */,
+				AEC6D9842B015BE700ED0E7C /* PrivacyPolicyDetailView.swift in Sources */,
 				AEB33EA92ACAADE00082A3E7 /* PDFFormLocation.swift in Sources */,
 				03FFF2D12AE6AD2C00B81D65 /* SubmitLoadingView.swift in Sources */,
 				AEB33E9B2AC406600082A3E7 /* Color+Palette.swift in Sources */,

--- a/Onbom/Onbom/Core/PDF/PDFManager.swift
+++ b/Onbom/Onbom/Core/PDF/PDFManager.swift
@@ -16,7 +16,7 @@ enum PDFError: String, Error {
 class PDFManager: ObservableObject {
     @Published var PDFDatas: [Data] = []
 
-    let signatureRect: CGRect = CGRect(x: 280, y: 250, width: 500, height: 250)
+    let signatureSize: CGSize = CGSize(width: 500, height: 250)
     let imageSizeFloat: CGFloat = 0.5
     enum FixedPositionItems: CaseIterable {
             case apply
@@ -32,16 +32,17 @@ class PDFManager: ObservableObject {
         // MARK: 첫번째 페이지
         if let firstPage = pdfDocument.page(at: 0) {
             // 고정된 정보
-            for item in Array(FixedPositionItems.allCases.prefix(2)) {
+            for item in Array(FixedPositionItems.allCases.prefix(1)) {
                 switch item {
                 case .apply:
                     addTextAnnotation(page: firstPage, bounds: CGRect(x: 168, y: 742, width: 140, height: 20), content: "✓")
                 default:
-                    continue
+                    break
                 }
             }
             // 환자
-            for value in patient.dictionary.values {
+            for (key, value) in patient.dictionary {
+                if patient.isSameAddress && key == "actualAddress" { continue }
                 addTextAnnotation(page: firstPage, bounds:value.position, content: value.answer)
             }
             // 대리인
@@ -63,7 +64,7 @@ class PDFManager: ObservableObject {
                 formatter.dateFormat = "yyyy        MM        dd"
                 let currentDate = formatter.string(from: Date())
                 // 고정된 정보
-                for item in Array(FixedPositionItems.allCases.suffix(3)) {
+                for item in Array(FixedPositionItems.allCases.suffix(4)) {
                     switch item {
                     case .mailReceive:
                         addTextAnnotation(page: secondPage, bounds:CGRect(x: 342, y: 733, width: 140, height: 20), content: "✓")
@@ -106,14 +107,14 @@ class PDFManager: ObservableObject {
                 linePath.lineWidth = 20
                 
                 guard !line.isEmpty else { continue }
-                let reversedLine = line.map { CGPoint(x: $0.x, y: signatureRect.height - $0.y) }
+                let reversedLine = line.map { CGPoint(x: $0.x, y: signatureSize.height - $0.y) }
                 linePath.move(to: reversedLine[0])
                 
                 for pointIndex in 1..<reversedLine.count {
                     linePath.addLine(to: reversedLine[pointIndex])
                 }
                 
-                let scaleFactor = CGSize(width: desiredSize.width / signatureRect.width, height: desiredSize.height / signatureRect.height)
+                let scaleFactor = CGSize(width: desiredSize.width / signatureSize.width, height: desiredSize.height / signatureSize.height)
                 linePath.apply(CGAffineTransform(scaleX: scaleFactor.width, y: scaleFactor.height))
                 
                 let adjustedBounds = CGRect(x: 440, y: 388, width: desiredSize.width, height: desiredSize.height)

--- a/Onbom/Onbom/Core/PDF/PDFManager.swift
+++ b/Onbom/Onbom/Core/PDF/PDFManager.swift
@@ -12,10 +12,11 @@ enum PDFError: String, Error {
     case NullError = "pdf가 존재하지 않습니다"
 }
 
-// TODO: ObservableObject 제외, 싱글톤으로 변경
 class PDFManager: ObservableObject {
-    @Published var PDFDatas: [Data] = []
-
+    static let shared = PDFManager()
+    private init() {}
+    
+    var PDFDatas: [Data] = []
     let signatureSize: CGSize = CGSize(width: 500, height: 250)
     let imageSizeFloat: CGFloat = 0.5
     enum FixedPositionItems: CaseIterable {

--- a/Onbom/Onbom/Core/PDF/PDFManager.swift
+++ b/Onbom/Onbom/Core/PDF/PDFManager.swift
@@ -99,6 +99,8 @@ class PDFManager: ObservableObject {
     
     // MARK: 전자서명 추가하는 함수
     func addSignatureToPDF(lines: [[CGPoint]], page: PDFPage) {
+        let desiredSize = CGSize(width: 130, height: 80)
+        
             for line in lines {
                 let linePath = UIBezierPath()
                 linePath.lineWidth = 20
@@ -111,7 +113,12 @@ class PDFManager: ObservableObject {
                     linePath.addLine(to: reversedLine[pointIndex])
                 }
                 
-                let lineAnnotation = PDFAnnotation(bounds: signatureRect, forType: .ink, withProperties: nil)
+                let scaleFactor = CGSize(width: desiredSize.width / signatureRect.width, height: desiredSize.height / signatureRect.height)
+                linePath.apply(CGAffineTransform(scaleX: scaleFactor.width, y: scaleFactor.height))
+                
+                let adjustedBounds = CGRect(x: 440, y: 388, width: desiredSize.width, height: desiredSize.height)
+                let lineAnnotation = PDFAnnotation(bounds: adjustedBounds, forType: .ink, withProperties: nil)
+                
                 lineAnnotation.add(linePath)
                 page.addAnnotation(lineAnnotation)
             }

--- a/Onbom/Onbom/Model/Patient.swift
+++ b/Onbom/Onbom/Model/Patient.swift
@@ -22,6 +22,7 @@ class Patient: ObservableObject {
     @Published var phoneNumber: String = ""
     @Published var hasInfectiousDisease = false
     @Published var hasMentalDisorder = false
+    var isSameAddress = false
     
     init() {}
     

--- a/Onbom/Onbom/View/LTCI/Address/AddressFormView.swift
+++ b/Onbom/Onbom/View/LTCI/Address/AddressFormView.swift
@@ -159,6 +159,7 @@ struct AddressFormView: View {
                     CTAButton.CustomButtonView(style: .secondary) {
                         patient.address = address
                         patient.actualAddress = address
+                        patient.isSameAddress = true
                         hideKeyboard()
                         showActualAddressCheckView = false
                         navigation.navigate(.StepView_Second)
@@ -169,6 +170,7 @@ struct AddressFormView: View {
                     CTAButton.CustomButtonView(style: .secondary) {
                         showActualAddressCheckView = false
                         patient.address = address
+                        patient.isSameAddress = false
                         hideKeyboard()
                         navigation.navigate(.AddressFormView_ActualPatient)
                     } label: {

--- a/Onbom/Onbom/View/LTCI/ApplyTypeView.swift
+++ b/Onbom/Onbom/View/LTCI/ApplyTypeView.swift
@@ -61,7 +61,7 @@ struct ApplyTypeView: View {
             .padding(20)
             .sheet(isPresented: $isPrivacyPolicyViewPresented) {
                 PrivacyPolicyView(isPrivacyPolicyViewPresented: $isPrivacyPolicyViewPresented)
-                    .presentationDetents([.fraction(0.4)])
+                    .presentationDetents([.fraction(0.41)])
             }
             
             if isPrivacyPolicyViewPresented {

--- a/Onbom/Onbom/View/LTCI/HomeView.swift
+++ b/Onbom/Onbom/View/LTCI/HomeView.swift
@@ -299,6 +299,6 @@ struct HomeView_Previews: PreviewProvider {
     static var previews: some View {
         HomeView(viewModel: HomeViewModel())
             .environmentObject(NavigationManager())
-            .environmentObject(PDFManager())
+            .environmentObject(PDFManager.shared)
     }
 }

--- a/Onbom/Onbom/View/LTCI/HomeView.swift
+++ b/Onbom/Onbom/View/LTCI/HomeView.swift
@@ -13,11 +13,10 @@ struct HomeView: View {
     private let timer = Timer.publish(every: 8, on: .main, in: .common).autoconnect()
     @State private var selectedPage = 0
     @StateObject var viewModel = HomeViewModel()
-    
     @EnvironmentObject var navigation: NavigationManager
-    @EnvironmentObject var pdfManager: PDFManager
     @EnvironmentObject var patient: Patient
     @EnvironmentObject var agent: Agent
+    private let pdfManager: PDFManager = .shared
     let width = UIScreen.main.bounds.width
     
     var body: some View {
@@ -299,6 +298,5 @@ struct HomeView_Previews: PreviewProvider {
     static var previews: some View {
         HomeView(viewModel: HomeViewModel())
             .environmentObject(NavigationManager())
-            .environmentObject(PDFManager.shared)
     }
 }

--- a/Onbom/Onbom/View/LTCI/MainView.swift
+++ b/Onbom/Onbom/View/LTCI/MainView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct MainView: View {
     @StateObject private var navigation = NavigationManager()
-    @StateObject private var pdfManager = PDFManager.shared
+    private let pdfManager: PDFManager = .shared
     @State private var tab: Tabs = .home
     
     var body: some View {
@@ -20,7 +20,7 @@ struct MainView: View {
                     HomeView()
                 }
                 .environmentObject(navigation)
-                .environmentObject(pdfManager)
+
             case .history:
                 PDFViewer(pdfData: pdfManager.PDFDatas.first )
                     .frame(maxHeight: .infinity)
@@ -43,6 +43,5 @@ struct MainView_Previews: PreviewProvider {
     static var previews: some View {
         MainView()
             .environmentObject(NavigationManager())
-            .environmentObject(PDFManager.shared)
     }
 }

--- a/Onbom/Onbom/View/LTCI/MainView.swift
+++ b/Onbom/Onbom/View/LTCI/MainView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct MainView: View {
     @StateObject private var navigation = NavigationManager()
-    @StateObject private var pdfManager = PDFManager()
+    @StateObject private var pdfManager = PDFManager.shared
     @State private var tab: Tabs = .home
     
     var body: some View {
@@ -43,6 +43,6 @@ struct MainView_Previews: PreviewProvider {
     static var previews: some View {
         MainView()
             .environmentObject(NavigationManager())
-            .environmentObject(PDFManager())
+            .environmentObject(PDFManager.shared)
     }
 }

--- a/Onbom/Onbom/View/LTCI/PrivacyPolicyDetailView.swift
+++ b/Onbom/Onbom/View/LTCI/PrivacyPolicyDetailView.swift
@@ -1,0 +1,18 @@
+//
+//  PrivacyPolicyDetailView.swift
+//  Onbom
+//
+//  Created by Sebin Kwon on 11/13/23.
+//
+
+import SwiftUI
+
+struct PrivacyPolicyDetailView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    PrivacyPolicyDetailView()
+}

--- a/Onbom/Onbom/View/LTCI/PrivacyPolicyDetailView.swift
+++ b/Onbom/Onbom/View/LTCI/PrivacyPolicyDetailView.swift
@@ -6,13 +6,40 @@
 //
 
 import SwiftUI
+import WebKit
 
 struct PrivacyPolicyDetailView: View {
+    @Binding var isShowPrivacyPolicyDetail: Bool
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack(alignment: .leading) {
+            Button {
+                isShowPrivacyPolicyDetail = false
+            } label: {
+                Image(systemName: "xmark")
+                    .foregroundStyle(Color.G5)
+            }
+            .padding(.horizontal)
+            MyWebView(urlToLoad: "https://lateral-donkey-cf6.notion.site/7e4a8717592040078e844a8f87744a25?pvs=4")
+        }
     }
 }
 
+struct MyWebView: UIViewRepresentable {
+    var urlToLoad: String
+
+    func makeUIView(context: Context) -> WKWebView {
+        guard let url = URL(string: self.urlToLoad) else {
+            return WKWebView()
+        }
+        let webView = WKWebView()
+        webView.load(URLRequest(url: url))
+        return webView
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: UIViewRepresentableContext<MyWebView>) {
+    }
+}
+ 
 #Preview {
-    PrivacyPolicyDetailView()
+    PrivacyPolicyDetailView(isShowPrivacyPolicyDetail: .constant(true))
 }

--- a/Onbom/Onbom/View/LTCI/PrivacyPolicyView.swift
+++ b/Onbom/Onbom/View/LTCI/PrivacyPolicyView.swift
@@ -22,7 +22,7 @@ struct PrivacyPolicyView: View {
                 Divider()
                     .padding(.bottom, 18)
                     .padding(.top, 8)
-                VStack(spacing: 18) {
+                VStack(spacing: 22) {
                     ForEach(Array(policyTextArray.enumerated()), id: \.element) { index, policyText in
                         HStack() {
                             PrivacyPolicyLow(policyText: policyText, isCheck: $isCheckArray[index], isAllCheck: $isAllCheck)
@@ -38,12 +38,10 @@ struct PrivacyPolicyView: View {
                     isAllCheck = true
                 }
             }
-            .padding(.bottom, 8)
             CTAButton.CustomButtonView(
                 style: .primary(isDisabled: !isAllCheck))
             {
                 if isAllCheck {
-                    // Date() 저장하기
                     isPrivacyPolicyViewPresented = false
                     navigation.navigate(.StepView_First)
                 }
@@ -57,12 +55,10 @@ struct PrivacyPolicyView: View {
     
     private var allCheckButton: some View {
         HStack {
-            // TODO: 에셋 교체
-            Image(systemName: "checkmark.circle.fill")
+            Image(isAllCheck ? "selectedCircle" : "defaultCircle")
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 20)
-                .foregroundColor(isAllCheck ? .Green4 : .G3)
             Text("개인정보 처리에 모두 동의합니다.")
                 .T1()
                 .foregroundColor(.B)
@@ -84,7 +80,6 @@ struct PrivacyPolicyLow: View {
     @Binding var isAllCheck: Bool
     var body: some View {
         HStack(spacing: 18) {
-            // TODO: 에셋 교체
             Image(systemName: "checkmark")
                 .foregroundColor(isAllCheck || isCheck ? .Green4 : .G4)
                 .font(.system(size: 12, weight: .bold))
@@ -95,14 +90,11 @@ struct PrivacyPolicyLow: View {
             Button {
                 isShowPrivacyPolicyDetail = true
             } label: {
-            // TODO: 패딩 확인하기 색상 확인하기
                 Image("chevronRight")
             }
-            // TODO: 현재 약관에 대한 페이지가 없어서 비활성화 처리. 근데 오른쪽 chevron을 눌러도 체크가 됨. 약관이 무조건 있을 꺼니까 상관 없을려나요?
-            .disabled(true)
         }
         .fullScreenCover(isPresented: $isShowPrivacyPolicyDetail) {
-            PrivacyPolicyDetailView(detail: policyText, isShowPrivacyPolicyDetail: $isShowPrivacyPolicyDetail)
+            PrivacyPolicyDetailView(isShowPrivacyPolicyDetail: $isShowPrivacyPolicyDetail)
         }
         .onTapGesture {
             if isAllCheck {
@@ -115,22 +107,6 @@ struct PrivacyPolicyLow: View {
         .onChange(of: isAllCheck) { newValue in
             if isAllCheck {
                 isCheck = isAllCheck
-            }
-        }
-    }
-}
-
-// TODO: 임시 개인정보 처리 디테일 뷰. 자세한 컨텐츠 나오면 파일 분리 예정
-struct PrivacyPolicyDetailView: View {
-    var detail: String
-    @Binding var isShowPrivacyPolicyDetail: Bool
-    var body: some View {
-        VStack {
-            Text(detail)
-            Button {
-                isShowPrivacyPolicyDetail = false
-            } label: {
-                Text("닫기")
             }
         }
     }

--- a/Onbom/Onbom/View/LTCI/SubmitCheckListView.swift
+++ b/Onbom/Onbom/View/LTCI/SubmitCheckListView.swift
@@ -13,7 +13,7 @@ struct SubmitCheckListView: View {
     @EnvironmentObject var agent: Agent
     
     // MARK: - pdf 생성 관련 변수
-    @EnvironmentObject var pdfManager: PDFManager
+    private let pdfManager: PDFManager = .shared
     
     // MARK: - navigation 관련 변수
     @State private var isSubmitLoadingViewPresented = false

--- a/Onbom/Onbom/View/LTCI/SubmitLoadingView.swift
+++ b/Onbom/Onbom/View/LTCI/SubmitLoadingView.swift
@@ -16,7 +16,7 @@ struct SubmitLoadingView: View {
     @State private var state: SubmitLoadingViewState = .loading
     @Binding var presented: Bool
     private let firebaseStorageManager: FirebaseStorageManager = .shared
-    @EnvironmentObject var pdfManager: PDFManager
+    private let pdfManager: PDFManager = .shared
     @Environment(\.dismiss) var dismiss
     
     var body: some View {

--- a/Onbom/Onbom/View/LTCI/SubmitView.swift
+++ b/Onbom/Onbom/View/LTCI/SubmitView.swift
@@ -11,7 +11,6 @@ struct SubmitView: View {
     @EnvironmentObject var navigation: NavigationManager
     @EnvironmentObject var patient: Patient
     @EnvironmentObject var agent: Agent
-    @EnvironmentObject var pdfManager: PDFManager
     @State private var isloadingViewPresented = true
     @ObservedObject var homeViewModel: HomeViewModel
     


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- #147 

👷 **작업한 내용**
- PDF 서명 크기 줄임
- SubmitView에서 PDFManager 삭제
- 우편물 수령인 안나오는 이슈 해결
- 실거주지 저장하면서 주소지와 같을 경우 pdf에는 안보이게 처리
- PrivacyPolicyLow 에셋 교체 및 디테일 조정
    - Image(systemName: "checkmark") SF Symbol이 맞음
- PrivacyPolicyDetailView 파일 분리 및 웹뷰 추가
- PDFManager 싱글톤으로 변경
    ```swift
    private let pdfManager: PDFManager = .shared
    
    class PDFManager: ObservableObject {
        static let shared = PDFManager()
        private init() {}
    ```

## 🚨 참고 사항
- 

## 📸 스크린샷
|PrivacyPolicyLow|WebView|
|:--:|:--:|
|<img src = "https://github.com/DeveloperAcademy-POSTECH/MacC-Team2-Nutty/assets/102914072/a986918b-3615-4575-a6c8-aaa73e60130e">|<img src = "https://github.com/DeveloperAcademy-POSTECH/MacC-Team2-Nutty/assets/102914072/3c0e6958-53d8-4d93-81cf-31d6cfc6117b">

## 📟 관련 이슈
- Resolved: #
