### PR TITLE
185 refactoring pdfviewer applyhistoryview and connent detailrelation to pdf

### DIFF
--- a/Onbom/Onbom.xcodeproj/project.pbxproj
+++ b/Onbom/Onbom.xcodeproj/project.pbxproj
@@ -1009,6 +1009,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = Nutty.Onbom;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/Onbom/Onbom/Components/LTCICardBack.swift
+++ b/Onbom/Onbom/Components/LTCICardBack.swift
@@ -36,13 +36,7 @@ struct LTCICardBack: View {
                 Spacer()
             }
             .padding(.horizontal, 20)
-            .padding(.bottom, 24)
-            
-            Rectangle()
-                .fill(Color.G3)
-                .frame(height: 98)
-                .padding(.horizontal, 20)
-                .padding(.bottom, 24)
+            .padding(.bottom, 80)
             ZStack(alignment: .leading) {
                 GeometryReader { geometry in
                     Capsule()

--- a/Onbom/Onbom/Core/PDF/PDFManager.swift
+++ b/Onbom/Onbom/Core/PDF/PDFManager.swift
@@ -61,7 +61,6 @@ class PDFManager: ObservableObject {
                 default:
                     addTextAnnotation(page: firstPage, bounds:value.position, content: value.answer)
                 }
-                addTextAnnotation(page: firstPage, bounds:CGRect(x: 477, y: 322, width: 140, height: 20), content: "상세 관계")
             }
         }
             

--- a/Onbom/Onbom/Core/PDF/PDFManager.swift
+++ b/Onbom/Onbom/Core/PDF/PDFManager.swift
@@ -20,7 +20,8 @@ class PDFManager: ObservableObject {
     let signatureSize: CGSize = CGSize(width: 500, height: 250)
     let imageSizeFloat: CGFloat = 0.5
     enum FixedPositionItems: CaseIterable {
-            case apply
+            case applyType
+            case isProtector
             case mailReceive
             case mailAddress
             case todayDate
@@ -37,10 +38,12 @@ class PDFManager: ObservableObject {
         // MARK: 첫번째 페이지
         if let firstPage = pdfDocument.page(at: 0) {
             // 고정된 정보
-            for item in Array(FixedPositionItems.allCases.prefix(1)) {
+            for item in Array(FixedPositionItems.allCases.prefix(2)) {
                 switch item {
-                case .apply:
+                case .applyType:
                     addTextAnnotation(page: firstPage, bounds: CGRect(x: 168, y: 742, width: 140, height: 20), content: "✓")
+                case .isProtector:
+                    addTextAnnotation(page: firstPage, bounds: CGRect(x: 181, y: 206, width: 140, height: 20), content: "✓")
                 default:
                     break
                 }

--- a/Onbom/Onbom/Core/PDF/PDFViewer.swift
+++ b/Onbom/Onbom/Core/PDF/PDFViewer.swift
@@ -9,8 +9,19 @@ import SwiftUI
 import PDFKit
 
 struct PDFViewer: UIViewRepresentable {
-    var pdfData: Data?
+    private let pdfManager: PDFManager = .shared
+    let pdfDocument: PDFDocument
     @Binding var pageIndex: Int
+    
+    init(pdfDocument: PDFDocument = PDFDocument(url: LTCIFormResource)!, pageIndex: Binding<Int>) {
+        if let pdfDocument = PDFDocument(data: pdfManager.PDFDatas.first ?? Data()) {
+            self.pdfDocument = pdfDocument
+        } else {
+            self.pdfDocument = pdfDocument
+        }
+        self._pageIndex = pageIndex
+    }
+    
     func makeUIView(context: Context) -> some UIView {
         let pdfView = PDFView()
         return pdfView
@@ -23,18 +34,15 @@ struct PDFViewer: UIViewRepresentable {
     }
     
     private func setupPDFView(_ pdfView: PDFView) {
-        if let pdfData {
-            pdfView.document = PDFDocument(data: pdfData)
-        } else {
-            pdfView.document = PDFDocument(url: LTCIFormResource)
-        }
+        let minScale: CGFloat = UIScreen.main.bounds.height * 0.00075
+        pdfView.document = pdfDocument
         if let page = pdfView.document?.page(at: pageIndex) {
             pdfView.go(to: page)
         }
         pdfView.displayMode = .singlePage
         pdfView.backgroundColor = UIColor(Color(.black).opacity(0.8))
-        pdfView.autoScales = true
-        pdfView.minScaleFactor = UIScreen.main.bounds.height * 0.00075
+        pdfView.scaleFactor = minScale
+        pdfView.minScaleFactor = minScale
         pdfView.maxScaleFactor = 3.0
     }
 }

--- a/Onbom/Onbom/Model/Agent.swift
+++ b/Onbom/Onbom/Model/Agent.swift
@@ -12,6 +12,7 @@ class Agent: ObservableObject {
         "name":("김유진", CGRect(x: 158, y: 450, width: 140, height: 20)),
         "id":("", CGRect(x: 395, y: 450, width: 150, height: 20)),
         "relation":("", CGRect(x: 183, y: 320, width: 140, height: 20)),
+        "detailRelation":("", CGRect(x: 478, y: 322, width: 140, height: 20)),
         "address":("", CGRect(x: 158, y: 413, width: 380, height: 20)),
         "phoneNumber":("", CGRect(x: 158, y: 368, width: 140, height: 20)),
     ]
@@ -56,6 +57,7 @@ class Agent: ObservableObject {
         dictionary["name"]?.answer = name
         dictionary["id"]?.answer = id
         dictionary["relation"]?.answer = relation
+        dictionary["detailRelation"]?.answer = detailRelation
         dictionary["address"]?.answer = "\(address.cityAddress)  \(address.detailAddress)"
         dictionary["phoneNumber"]?.answer = phoneNumber
     }

--- a/Onbom/Onbom/View/LTCI/ApplyHistoryView.swift
+++ b/Onbom/Onbom/View/LTCI/ApplyHistoryView.swift
@@ -60,18 +60,16 @@ struct ApplyHistoryView: View {
                             Spacer()
                         }
                         HStack {
-                            if let pdfDocument = PDFDocument(data: pdfManager.PDFDatas.first ?? Data()) {
+                            if let pdfDocument = PDFDocument(data: pdfManager.PDFDatas.first ?? Data()) ?? PDFDocument(url: LTCIFormResource) {
                                 ForEach(0..<pdfDocument.pageCount, id: \.self) { pageIndex in
-                                    ThumbnailView(thumbnailImage: thumbnail(from: pdfDocument.page(at: pageIndex)!, size: CGSize(width: 500, height: 500)))
+                                    ThumbnailView(thumbnailImage: thumbnail(from: pdfDocument.page(at: pageIndex)!))
                                         .onTapGesture {
                                             selectedPageIndex = pageIndex
-                                            withAnimation {
-                                                isShowPdf = true
-                                            }
+                                            isShowPdf = true
                                         }
                                         .fullScreenCover(isPresented: $isShowPdf) {
-                                                PDFDetailView(selectedPageIndex: $selectedPageIndex, isShowPdf: $isShowPdf)
-                                                    .ignoresSafeArea(.all)
+                                            PDFDetailView(selectedPageIndex: $selectedPageIndex, isShowPdf: $isShowPdf)
+                                                .ignoresSafeArea(.all)
                                         }
                                 }
                             }
@@ -157,7 +155,8 @@ struct ApplyHistoryView: View {
             .frame(maxWidth: .infinity)
     }
     
-    func thumbnail(from page: PDFPage, size: CGSize) -> UIImage {
+    func thumbnail(from page: PDFPage) -> UIImage {
+        let size: CGSize = CGSize(width: 500, height: 500)
         let pdfView = PDFView()
         pdfView.document = PDFDocument()
         pdfView.document?.insert(page, at: 0)
@@ -190,7 +189,7 @@ struct PDFDetailView: View {
     
     var body: some View {
         ZStack(alignment: .top) {
-            PDFViewer(pdfData: pdfManager.PDFDatas.first ?? Data(), pageIndex: $selectedPageIndex)
+            PDFViewer(pageIndex: $selectedPageIndex)
             Rectangle()
                 .frame(maxWidth: .infinity, maxHeight: 90)
                 .foregroundStyle(.black.opacity(0.55))


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- #185 

👷 **작업한 내용**
- PDFViewer의 iOS17에서만 발생한 사이즈 이슈 해결
- PDFViewer와 ApplyHistoryView 리팩토링
- 대리인 상세관계를 PDF와 연결
- LTCI Card 회색 박스 삭제
- PDFManager 보호자 있음 체크 표시

## 🚨 참고 사항

## 📸 스크린샷
|신청 후 메인화면 카드|신청관계에 '딸'이 들어간 모습|
|:--:|:--:|
|<img src ="https://github.com/DeveloperAcademy-POSTECH/MacC-Team2-Nutty/assets/102914072/0e0f15aa-df03-4c5a-b51d-528e3369c013" width="300">|<img src ="https://github.com/DeveloperAcademy-POSTECH/MacC-Team2-Nutty/assets/102914072/a2c1cb72-5d18-4dd7-a454-b8d0b832cca3" width="300">



## 📟 관련 이슈
- Resolved: #
